### PR TITLE
try snap exec path on linux

### DIFF
--- a/viewscad/renderer.py
+++ b/viewscad/renderer.py
@@ -210,6 +210,8 @@ class Renderer:
             self._try_executable('/usr/bin/openscad')
             if self.openscad_exec is None:
                 self._try_executable('/usr/local/bin/openscad')
+                if self.openscad_exec is None:
+                    self._try_executable('/snap/bin/openscad')
         elif platfm == 'Darwin':
             self._try_executable('/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD')
         elif platfm == 'Windows':


### PR DESCRIPTION
Nowadays it's common/preferred to install packages with snap on Linux/Ubuntu:

    sudo snap install openscad

Also try snap path on linux.

Signed-off-by: Joe Guo <joe.guo@canonical.com>